### PR TITLE
change travis language to cpp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: linux
-language: ruby
+language: cpp
 matrix:
   include:
     - env: TEST=shellcheck


### PR DESCRIPTION
This may or may not run slightly faster than `language: ruby` (the default).